### PR TITLE
Add runtime error handling and debug overlay

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,7 +9,7 @@ const tsRules = {
 
 export default [
   {
-    ignores: ['dist', 'node_modules', 'eslint.config.js']
+    ignores: ['dist', 'node_modules', 'eslint.config.js', 'vite.config.d.ts']
   },
   js.configs.recommended,
   {

--- a/index.html
+++ b/index.html
@@ -148,6 +148,226 @@
         color: rgba(224, 236, 255, 0.9);
         font-size: 0.8rem;
       }
+
+      .error-screen {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 24px;
+        background: radial-gradient(circle at 50% 40%, rgba(4, 7, 13, 0.85), rgba(2, 4, 8, 0.95));
+        backdrop-filter: blur(12px);
+        z-index: 55;
+      }
+
+      .error-screen__content {
+        width: min(480px, 100%);
+        padding: 28px;
+        border-radius: 20px;
+        border: 1px solid rgba(120, 150, 220, 0.25);
+        background: rgba(12, 18, 28, 0.92);
+        box-shadow: 0 20px 60px rgba(0, 0, 0, 0.55);
+        text-align: left;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+
+      .error-screen__title {
+        margin: 0;
+        font-size: 1.2rem;
+        font-weight: 600;
+        color: #ff9a9a;
+      }
+
+      .error-screen__message {
+        margin: 0;
+        font-size: 0.95rem;
+        line-height: 1.6;
+      }
+
+      .error-screen__description {
+        margin: 0;
+        font-size: 0.85rem;
+        line-height: 1.6;
+        color: rgba(200, 210, 240, 0.85);
+      }
+
+      .error-screen__details {
+        margin: 0;
+        max-height: 220px;
+        overflow: auto;
+        padding: 14px;
+        border-radius: 12px;
+        background: rgba(6, 10, 18, 0.8);
+        border: 1px solid rgba(80, 110, 180, 0.3);
+        font-family: 'JetBrains Mono', 'Fira Mono', monospace;
+        font-size: 0.75rem;
+        line-height: 1.5;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+
+      .error-screen__button {
+        align-self: flex-end;
+        appearance: none;
+        border: none;
+        border-radius: 12px;
+        padding: 12px 18px;
+        font-weight: 600;
+        font-size: 0.9rem;
+        background: linear-gradient(135deg, rgba(255, 115, 115, 0.95), rgba(255, 163, 163, 0.85));
+        color: #0b101c;
+        cursor: pointer;
+      }
+
+      .debug-overlay {
+        position: absolute;
+        top: 16px;
+        left: 16px;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+        z-index: 70;
+        pointer-events: none;
+      }
+
+      .debug-toggle {
+        pointer-events: auto;
+        border: none;
+        border-radius: 999px;
+        width: 42px;
+        height: 42px;
+        display: grid;
+        place-items: center;
+        background: rgba(20, 30, 48, 0.85);
+        color: rgba(180, 210, 255, 0.9);
+        font-size: 1.2rem;
+        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
+        cursor: pointer;
+      }
+
+      .debug-panel {
+        pointer-events: auto;
+        width: min(340px, calc(100vw - 32px));
+        max-height: 60vh;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        padding: 16px;
+        border-radius: 16px;
+        border: 1px solid rgba(90, 120, 200, 0.35);
+        background: rgba(8, 12, 22, 0.92);
+        box-shadow: 0 18px 48px rgba(0, 0, 0, 0.55);
+      }
+
+      .debug-panel__header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+      }
+
+      .debug-panel__summary {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+
+      .debug-panel__title {
+        font-size: 0.85rem;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: rgba(160, 190, 255, 0.9);
+      }
+
+      .debug-panel__status {
+        font-size: 0.78rem;
+        color: rgba(200, 220, 255, 0.75);
+      }
+
+      .debug-panel__status[data-level='error'] {
+        color: #ff9a9a;
+      }
+
+      .debug-panel__actions {
+        display: flex;
+        gap: 8px;
+      }
+
+      .debug-panel__action {
+        border: 1px solid rgba(90, 120, 200, 0.4);
+        border-radius: 10px;
+        background: rgba(12, 18, 30, 0.9);
+        color: rgba(200, 220, 255, 0.88);
+        font-size: 0.72rem;
+        padding: 6px 10px;
+        cursor: pointer;
+      }
+
+      .debug-panel__list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+        overflow-y: auto;
+        padding-right: 4px;
+      }
+
+      .debug-panel__entry {
+        border-radius: 12px;
+        padding: 10px;
+        background: rgba(18, 26, 40, 0.85);
+        border-left: 3px solid rgba(120, 150, 210, 0.4);
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+
+      .debug-panel__entry--warn {
+        border-left-color: rgba(255, 196, 120, 0.8);
+      }
+
+      .debug-panel__entry--error {
+        border-left-color: rgba(255, 120, 120, 0.85);
+      }
+
+      .debug-panel__entry-header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 12px;
+      }
+
+      .debug-panel__time {
+        font-family: 'JetBrains Mono', 'Fira Mono', monospace;
+        font-size: 0.7rem;
+        color: rgba(150, 180, 230, 0.8);
+      }
+
+      .debug-panel__message {
+        font-size: 0.82rem;
+        color: rgba(220, 230, 255, 0.9);
+        flex: 1;
+      }
+
+      .debug-panel__details {
+        font-family: 'JetBrains Mono', 'Fira Mono', monospace;
+        font-size: 0.7rem;
+        line-height: 1.5;
+        background: rgba(8, 12, 22, 0.9);
+        border-radius: 8px;
+        padding: 8px;
+        max-height: 160px;
+        overflow: auto;
+        white-space: pre-wrap;
+        word-break: break-word;
+        border: 1px solid rgba(70, 100, 170, 0.35);
+      }
     </style>
   </head>
   <body>

--- a/src/app/GameApp.ts
+++ b/src/app/GameApp.ts
@@ -14,6 +14,8 @@ import { trainDescriptor } from '../data/wagons';
 import { DialogueController } from '../ui/dialogue';
 import { HudController } from '../ui/hud';
 import { FadeController } from '../ui/fade';
+import { ErrorScreen } from '../ui/error';
+import { DebuggerOverlay } from '../ui/debugger';
 import { InteractionSystem } from '../systems/InteractionSystem';
 
 const GAME_CONFIG = {
@@ -42,6 +44,10 @@ export class GameApp {
 
   private readonly fade: FadeController;
 
+  private readonly errorScreen: ErrorScreen;
+
+  private readonly debug: DebuggerOverlay;
+
   private readonly train = new TrainGraph(trainDescriptor);
 
   private readonly movement: MovementSystem;
@@ -60,7 +66,15 @@ export class GameApp {
 
   private loopHandle = 0;
 
-  constructor(canvas: HTMLCanvasElement, overlayRoot: HTMLElement) {
+  private fatalError = false;
+
+  private destroyed = false;
+
+  constructor(
+    canvas: HTMLCanvasElement,
+    overlayRoot: HTMLElement,
+    overlays?: { errorScreen?: ErrorScreen; debugOverlay?: DebuggerOverlay },
+  ) {
     this.canvas = canvas;
     this.overlayRoot = overlayRoot;
     this.display = new CanvasDisplay(canvas, GAME_CONFIG);
@@ -68,6 +82,8 @@ export class GameApp {
     this.dialogue = new DialogueController(this.overlayRoot);
     this.fade = new FadeController(this.overlayRoot);
     this.hud = new HudController(this.overlayRoot, this.audio, this.toast);
+    this.errorScreen = overlays?.errorScreen ?? new ErrorScreen(this.overlayRoot);
+    this.debug = overlays?.debugOverlay ?? new DebuggerOverlay(this.overlayRoot);
 
     const wagon = this.train.getCurrentWagon();
     this.state = createRuntimeState(GAME_CONFIG, wagon, this.train.getState());
@@ -76,50 +92,84 @@ export class GameApp {
     this.renderer = new IsometricRenderer(this.display, this.state);
     this.buildTargetsForWagon(wagon);
     window.addEventListener('resize', () => this.display.resize());
+    this.debug.setStatus('Создание приложения');
+    this.debug.log('game.constructor', {
+      startWagon: wagon.id,
+      targets: this.state.currentTargets.length,
+    });
   }
 
   async init(): Promise<void> {
-    const ctx = await this.telegram.init();
-    this.userId = ctx.userId;
-    await this.verifyInitData(ctx.initDataRaw);
-    await this.audio.init();
-    await this.audio.playAmbient('train');
-    this.interaction = new InteractionSystem({
-      state: this.state,
-      movement: this.movement,
-      train: this.train,
-      dialogue: this.dialogue,
-      toast: this.toast,
-      audio: this.audio,
-      userId: this.userId,
-      onTravel: async (wagonId: string, spawnPoint: IsoPoint) => {
-        await this.travelTo(wagonId, spawnPoint);
-      },
-      onStateChanged: () => this.saveGame(),
-    });
-    const haptics: HapticsBridge = {
-      impact: (style: 'light' | 'medium' | 'heavy') => this.telegram.vibrate(style),
-      notify: (style: 'success' | 'warning' | 'error') => this.telegram.notify(style),
-    };
-    this.inputRouter = new InputRouter(this.canvas, this.state, this.interaction, haptics);
-    this.inputRouter.attach();
-    this.tryRestoreSave();
-    this.startLoop();
+    this.debug.log('game.init.start');
+    this.errorScreen.hide();
+    try {
+      const ctx = await this.guard('Получение контекста Telegram', () => this.telegram.init());
+      this.userId = ctx.userId;
+      this.debug.log('telegram.context', {
+        userId: this.userId,
+        hasInitData: Boolean(ctx.initDataRaw),
+      });
+      await this.guard('Проверка данных сессии', () => this.verifyInitData(ctx.initDataRaw));
+      await this.guard('Инициализация аудио', () => this.audio.init());
+      await this.guard('Запуск фонового звука', () => this.audio.playAmbient('train'));
+      await this.guard('Подготовка систем взаимодействия', () => {
+        this.interaction = new InteractionSystem({
+          state: this.state,
+          movement: this.movement,
+          train: this.train,
+          dialogue: this.dialogue,
+          toast: this.toast,
+          audio: this.audio,
+          userId: this.userId,
+          onTravel: async (wagonId: string, spawnPoint: IsoPoint) => {
+            await this.travelTo(wagonId, spawnPoint);
+          },
+          onStateChanged: () => this.saveGame(),
+        });
+        const haptics: HapticsBridge = {
+          impact: (style: 'light' | 'medium' | 'heavy') => this.telegram.vibrate(style),
+          notify: (style: 'success' | 'warning' | 'error') => this.telegram.notify(style),
+        };
+        this.inputRouter = new InputRouter(this.canvas, this.state, this.interaction, haptics);
+        this.inputRouter.attach();
+      });
+      await this.guard('Загрузка сохранения', () => this.tryRestoreSave());
+      this.startLoop();
+      this.debug.setStatus('Игра запущена');
+      this.debug.log('game.init.complete');
+    } catch (error) {
+      this.handleFatalError(error, 'инициализация');
+      throw error;
+    }
   }
 
   private tryRestoreSave(): void {
-    const save = loadSave(this.userId);
-    if (!save) {
-      return;
+    this.debug.log('save.restore.start');
+    try {
+      const save = loadSave(this.userId);
+      if (!save) {
+        this.debug.log('save.restore.empty');
+        return;
+      }
+      applySaveToState(this.state, save);
+      this.refreshDoorsFromFlags();
+      const wagon = this.train.travelTo(save.wagonId);
+      this.state.wagon = wagon;
+      this.movement.setNavMesh(wagon.navmesh);
+      this.state.player.position = save.position;
+      this.state.player.path = [];
+      this.buildTargetsForWagon(wagon);
+      this.debug.log('save.restore.success', {
+        wagonId: save.wagonId,
+        flags: save.flags.length,
+        endings: save.endings.length,
+        inventory: Object.keys(save.inventory ?? {}).length,
+      });
+    } catch (error) {
+      console.error('Failed to restore save', error);
+      this.debug.log('save.restore.error', error instanceof Error ? error : String(error), 'warn');
+      this.toast.show('Сохранение повреждено. Начинаем заново.');
     }
-    applySaveToState(this.state, save);
-    this.refreshDoorsFromFlags();
-    const wagon = this.train.travelTo(save.wagonId);
-    this.state.wagon = wagon;
-    this.movement.setNavMesh(wagon.navmesh);
-    this.state.player.position = save.position;
-    this.state.player.path = [];
-    this.buildTargetsForWagon(wagon);
   }
 
   private refreshDoorsFromFlags(): void {
@@ -134,7 +184,10 @@ export class GameApp {
 
   private buildTargetsForWagon(wagon: WagonLayerData): void {
     const targets: InteractionTarget[] = [];
-    wagon.doors.forEach((door) => {
+    const doors = wagon.doors ?? [];
+    const npcs = wagon.npcs ?? [];
+    const objects = wagon.objects ?? [];
+    doors.forEach((door) => {
       targets.push({
         id: door.id,
         kind: 'door',
@@ -143,7 +196,7 @@ export class GameApp {
         metadata: { door: { wagonId: wagon.id, descriptor: door } },
       });
     });
-    wagon.npcs.forEach((npc) => {
+    npcs.forEach((npc) => {
       targets.push({
         id: npc.id,
         kind: 'npc',
@@ -152,7 +205,7 @@ export class GameApp {
         metadata: { dialogueId: npc.dialogueId, name: npc.name },
       });
     });
-    wagon.objects.forEach((object) => {
+    objects.forEach((object) => {
       targets.push({
         id: object.id,
         kind: 'object',
@@ -162,6 +215,7 @@ export class GameApp {
       });
     });
     this.state.currentTargets = targets;
+    this.debug.log('targets.updated', { wagonId: wagon.id, targets: targets.length });
   }
 
   private async travelTo(wagonId: string, spawnPoint: IsoPoint): Promise<void> {
@@ -177,6 +231,7 @@ export class GameApp {
     await this.audio.playAmbient(wagon.ambient === 'dark' ? 'dark' : 'train');
     await this.fade.fadeIn();
     this.saveGame();
+    this.debug.log('travel.complete', { wagonId, spawnPoint });
   }
 
   private saveGame(): void {
@@ -199,26 +254,85 @@ export class GameApp {
     } catch (error) {
       console.error('InitData validation failed', error);
       this.toast.show('Проверка Telegram недоступна.');
+      this.debug.log('telegram.validation.failed', error instanceof Error ? error : String(error), 'warn');
     }
   }
 
   private startLoop(): void {
     const tick = (time: number) => {
+      if (this.destroyed || this.fatalError) {
+        return;
+      }
       const delta = (time - this.lastTime) / 1000;
       this.lastTime = time;
-      this.movement.update(delta);
-      this.renderer.render(delta);
+      try {
+        this.movement.update(delta);
+        this.renderer.render(delta);
+      } catch (error) {
+        this.handleFatalError(error, 'игровой цикл');
+        return;
+      }
       this.loopHandle = requestAnimationFrame(tick);
     };
     this.loopHandle = requestAnimationFrame(tick);
   }
 
   destroy(): void {
+    this.destroyed = true;
     if (this.loopHandle) {
       cancelAnimationFrame(this.loopHandle);
     }
     if (this.inputRouter) {
       this.inputRouter.detach();
+    }
+  }
+
+  private async guard<T>(stage: string, task: () => Promise<T> | T): Promise<T> {
+    this.debug.setStatus(`${stage}...`);
+    this.debug.log('stage.start', { stage });
+    try {
+      const result = await task();
+      this.debug.log('stage.success', { stage });
+      return result;
+    } catch (error) {
+      this.debug.setStatus(`Ошибка: ${stage}`, 'error');
+      this.debug.log('stage.error', { stage, error: this.describeError(error) }, 'error');
+      throw error;
+    }
+  }
+
+  private handleFatalError(error: unknown, stage: string): void {
+    if (this.fatalError) {
+      return;
+    }
+    this.fatalError = true;
+    this.destroy();
+    const normalized = this.describeError(error);
+    console.error(`Fatal error during ${stage}`, error);
+    this.debug.setStatus(`Критическая ошибка: ${stage}`, 'error');
+    this.debug.log('fatal', { stage, error: normalized }, 'error');
+    this.errorScreen.show({
+      title: 'Не удалось запустить игру',
+      message: `Этап «${stage}» завершился с ошибкой.`,
+      description:
+        'Попробуйте перезагрузить приложение. Если проблема повторяется, откройте отладчик (кнопка 🐞) и отправьте лог разработчику.',
+      details: normalized.stack ?? normalized.message,
+      actionLabel: 'Перезагрузить приложение',
+      onAction: () => window.location.reload(),
+    });
+  }
+
+  private describeError(error: unknown): { message: string; stack?: string } {
+    if (error instanceof Error) {
+      return { message: error.message, stack: error.stack ?? undefined };
+    }
+    if (typeof error === 'string') {
+      return { message: error };
+    }
+    try {
+      return { message: JSON.stringify(error) };
+    } catch (serializationError) {
+      return { message: String(serializationError ?? error) };
     }
   }
 }

--- a/src/ui/debugger.ts
+++ b/src/ui/debugger.ts
@@ -1,0 +1,248 @@
+export type DebugLevel = 'info' | 'warn' | 'error';
+
+interface DebugEntry {
+  id: string;
+  timestamp: number;
+  level: DebugLevel;
+  message: string;
+  details?: string;
+}
+
+export interface DebuggerApi {
+  log: (message: string, payload?: unknown, level?: DebugLevel) => void;
+  show: () => void;
+  hide: () => void;
+  entries: () => DebugEntry[];
+  setStatus: (status: string, level?: DebugLevel) => void;
+}
+
+export class DebuggerOverlay {
+  private readonly container: HTMLDivElement;
+
+  private readonly toggleButton: HTMLButtonElement;
+
+  private readonly panel: HTMLDivElement;
+
+  private readonly statusElement: HTMLSpanElement;
+
+  private readonly list: HTMLUListElement;
+
+  private readonly maxEntries = 80;
+
+  private entries: DebugEntry[] = [];
+
+  private visible = false;
+
+  constructor(root: HTMLElement) {
+    this.container = document.createElement('div');
+    this.container.className = 'debug-overlay';
+    this.container.dataset.role = 'ui-block';
+    this.container.style.pointerEvents = 'none';
+
+    this.toggleButton = document.createElement('button');
+    this.toggleButton.type = 'button';
+    this.toggleButton.className = 'debug-toggle';
+    this.toggleButton.textContent = '🐞';
+    this.toggleButton.title = 'Показать отладчик';
+    this.toggleButton.setAttribute('aria-expanded', 'false');
+    this.toggleButton.addEventListener('click', () => this.toggle());
+
+    this.panel = document.createElement('div');
+    this.panel.className = 'debug-panel';
+    this.panel.hidden = true;
+    this.panel.setAttribute('aria-hidden', 'true');
+
+    const header = document.createElement('div');
+    header.className = 'debug-panel__header';
+
+    const summary = document.createElement('div');
+    summary.className = 'debug-panel__summary';
+
+    const title = document.createElement('span');
+    title.className = 'debug-panel__title';
+    title.textContent = 'Отладка';
+
+    this.statusElement = document.createElement('span');
+    this.statusElement.className = 'debug-panel__status';
+    this.statusElement.textContent = 'Ожидание запуска';
+
+    summary.append(title, this.statusElement);
+
+    const actions = document.createElement('div');
+    actions.className = 'debug-panel__actions';
+
+    const copyButton = document.createElement('button');
+    copyButton.type = 'button';
+    copyButton.className = 'debug-panel__action';
+    copyButton.textContent = 'Скопировать лог';
+    copyButton.addEventListener('click', () => this.copyEntries());
+
+    const clearButton = document.createElement('button');
+    clearButton.type = 'button';
+    clearButton.className = 'debug-panel__action';
+    clearButton.textContent = 'Очистить';
+    clearButton.addEventListener('click', () => this.clear());
+
+    actions.append(copyButton, clearButton);
+
+    header.append(summary, actions);
+
+    this.list = document.createElement('ul');
+    this.list.className = 'debug-panel__list';
+
+    this.panel.append(header, this.list);
+
+    this.container.append(this.toggleButton, this.panel);
+    root.appendChild(this.container);
+
+    this.exposeToWindow();
+  }
+
+  log(message: string, payload?: unknown, level: DebugLevel = 'info'): void {
+    const entry: DebugEntry = {
+      id: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
+      timestamp: Date.now(),
+      level,
+      message,
+      details: payload !== undefined ? this.stringifyPayload(payload) : undefined,
+    };
+    this.entries.push(entry);
+    if (this.entries.length > this.maxEntries) {
+      this.entries = this.entries.slice(this.entries.length - this.maxEntries);
+    }
+    this.renderEntry(entry);
+    this.trimList();
+  }
+
+  setStatus(status: string, level: DebugLevel = 'info'): void {
+    this.statusElement.textContent = status;
+    this.statusElement.dataset.level = level;
+  }
+
+  show(): void {
+    this.visible = true;
+    this.panel.hidden = false;
+    this.panel.setAttribute('aria-hidden', 'false');
+    this.toggleButton.setAttribute('aria-expanded', 'true');
+  }
+
+  hide(): void {
+    this.visible = false;
+    this.panel.hidden = true;
+    this.panel.setAttribute('aria-hidden', 'true');
+    this.toggleButton.setAttribute('aria-expanded', 'false');
+  }
+
+  private toggle(): void {
+    if (this.visible) {
+      this.hide();
+    } else {
+      this.show();
+    }
+  }
+
+  private renderEntry(entry: DebugEntry): void {
+    const item = document.createElement('li');
+    item.className = `debug-panel__entry debug-panel__entry--${entry.level}`;
+
+    const header = document.createElement('div');
+    header.className = 'debug-panel__entry-header';
+
+    const time = document.createElement('span');
+    time.className = 'debug-panel__time';
+    time.textContent = this.formatTime(entry.timestamp);
+
+    const message = document.createElement('span');
+    message.className = 'debug-panel__message';
+    message.textContent = entry.message;
+
+    header.append(time, message);
+    item.appendChild(header);
+
+    if (entry.details) {
+      const details = document.createElement('pre');
+      details.className = 'debug-panel__details';
+      details.textContent = entry.details;
+      item.appendChild(details);
+    }
+
+    this.list.prepend(item);
+  }
+
+  private trimList(): void {
+    while (this.list.childElementCount > this.maxEntries) {
+      const last = this.list.lastElementChild;
+      if (!last) {
+        break;
+      }
+      this.list.removeChild(last);
+    }
+  }
+
+  private stringifyPayload(payload: unknown): string {
+    if (payload instanceof Error) {
+      return `${payload.name}: ${payload.message}` + (payload.stack ? `\n${payload.stack}` : '');
+    }
+    if (typeof payload === 'string') {
+      return payload;
+    }
+    try {
+      return JSON.stringify(payload, null, 2);
+    } catch (error) {
+      return String(payload);
+    }
+  }
+
+  private formatTime(timestamp: number): string {
+    const date = new Date(timestamp);
+    return date.toLocaleTimeString('ru-RU', { hour12: false });
+  }
+
+  private async copyEntries(): Promise<void> {
+    const text = this.entries
+      .map((entry) => {
+        const isoTime = new Date(entry.timestamp).toISOString();
+        const base = `[${isoTime}] ${entry.level.toUpperCase()} ${entry.message}`;
+        return entry.details ? `${base}\n${entry.details}` : base;
+      })
+      .join('\n\n');
+    const payload = text || 'Нет записей лога.';
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(payload);
+      } else {
+        const textarea = document.createElement('textarea');
+        textarea.value = payload;
+        textarea.setAttribute('readonly', 'true');
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand('copy');
+        textarea.remove();
+      }
+      this.log('debug.copy.success');
+    } catch (error) {
+      console.error('Failed to copy debug log', error);
+      this.log('debug.copy.error', error instanceof Error ? error : String(error), 'warn');
+    }
+  }
+
+  private clear(): void {
+    this.entries = [];
+    this.list.innerHTML = '';
+    this.log('debug.log.cleared');
+  }
+
+  private exposeToWindow(): void {
+    const globalWindow = window as typeof window & { deadTrainDebug?: DebuggerApi };
+    const api: DebuggerApi = {
+      log: (message, payload, level) => this.log(message, payload, level),
+      show: () => this.show(),
+      hide: () => this.hide(),
+      entries: () => [...this.entries],
+      setStatus: (status, level) => this.setStatus(status, level),
+    };
+    globalWindow.deadTrainDebug = api;
+  }
+}

--- a/src/ui/error.ts
+++ b/src/ui/error.ts
@@ -1,0 +1,119 @@
+export interface ErrorScreenOptions {
+  title?: string;
+  message: string;
+  description?: string;
+  details?: string;
+  actionLabel?: string;
+  onAction?: () => void;
+}
+
+export class ErrorScreen {
+  private readonly element: HTMLDivElement;
+
+  private readonly content: HTMLDivElement;
+
+  private readonly titleElement: HTMLHeadingElement;
+
+  private readonly messageElement: HTMLParagraphElement;
+
+  private readonly descriptionElement: HTMLParagraphElement;
+
+  private readonly detailsElement: HTMLPreElement;
+
+  private readonly actionButton: HTMLButtonElement;
+
+  private actionHandler: (() => void) | null = null;
+
+  private visible = false;
+
+  constructor(root: HTMLElement) {
+    this.element = document.createElement('div');
+    this.element.className = 'error-screen';
+    this.element.dataset.role = 'ui-block';
+    this.element.hidden = true;
+    this.element.style.pointerEvents = 'none';
+    this.element.setAttribute('role', 'alertdialog');
+    this.element.setAttribute('aria-live', 'assertive');
+
+    this.content = document.createElement('div');
+    this.content.className = 'error-screen__content';
+
+    this.titleElement = document.createElement('h2');
+    this.titleElement.className = 'error-screen__title';
+    this.titleElement.textContent = 'Ошибка запуска';
+
+    this.messageElement = document.createElement('p');
+    this.messageElement.className = 'error-screen__message';
+
+    this.descriptionElement = document.createElement('p');
+    this.descriptionElement.className = 'error-screen__description';
+    this.descriptionElement.hidden = true;
+
+    this.detailsElement = document.createElement('pre');
+    this.detailsElement.className = 'error-screen__details';
+    this.detailsElement.hidden = true;
+
+    this.actionButton = document.createElement('button');
+    this.actionButton.type = 'button';
+    this.actionButton.className = 'error-screen__button';
+    this.actionButton.textContent = 'Перезагрузить';
+    this.actionButton.addEventListener('click', () => {
+      if (this.actionHandler) {
+        this.actionHandler();
+        return;
+      }
+      window.location.reload();
+    });
+
+    this.content.append(
+      this.titleElement,
+      this.messageElement,
+      this.descriptionElement,
+      this.detailsElement,
+      this.actionButton,
+    );
+
+    this.element.appendChild(this.content);
+    root.appendChild(this.element);
+  }
+
+  show(options: ErrorScreenOptions): void {
+    this.titleElement.textContent = options.title ?? 'Что-то пошло не так';
+    this.messageElement.textContent = options.message;
+
+    if (options.description) {
+      this.descriptionElement.textContent = options.description;
+      this.descriptionElement.hidden = false;
+    } else {
+      this.descriptionElement.hidden = true;
+      this.descriptionElement.textContent = '';
+    }
+
+    if (options.details) {
+      this.detailsElement.textContent = options.details.trim();
+      this.detailsElement.hidden = false;
+    } else {
+      this.detailsElement.hidden = true;
+      this.detailsElement.textContent = '';
+    }
+
+    this.actionButton.textContent = options.actionLabel ?? 'Перезагрузить';
+    this.actionHandler = options.onAction ?? null;
+
+    this.visible = true;
+    this.element.hidden = false;
+    this.element.style.pointerEvents = 'auto';
+    this.element.setAttribute('aria-hidden', 'false');
+  }
+
+  hide(): void {
+    this.visible = false;
+    this.element.hidden = true;
+    this.element.style.pointerEvents = 'none';
+    this.element.setAttribute('aria-hidden', 'true');
+  }
+
+  isVisible(): boolean {
+    return this.visible;
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable error screen and debugger overlay components with corresponding styling
- wrap game initialization in guarded steps that report failures, surface an error screen, and expose debug logs
- ensure API body parsing and lint configuration satisfy linting after the new tooling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c94e075d4c832ca854d647c72c9559