### PR TITLE
Build frontend assets during Docker image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-lock.yaml
+.pnpm-store
+.vscode
+.idea
+.git
+.gitignore
+dist

--- a/dockerfile
+++ b/dockerfile
@@ -1,17 +1,23 @@
-# Используем официальный образ PHP с Apache
+# Этап сборки фронтенда
+FROM node:20-alpine AS build
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+# Этап доставки собранного бандла
 FROM php:7.4-apache
 
-# Включаем mod_rewrite
 RUN a2enmod rewrite
 
-# Копируем проект
-COPY . /var/www/html/
+COPY --from=build /app/dist/ /var/www/html/
 
-# Создаём папку userdata и даём права
 RUN mkdir -p /var/www/html/userdata && chmod -R 777 /var/www/html/userdata
 
-# Открываем порт 80
 EXPOSE 80
 
-# Запускаем Apache
 CMD ["apache2-foreground"]


### PR DESCRIPTION
## Summary
- add a multi-stage Docker build that compiles the Vite/TypeScript frontend before copying files into Apache
- add a .dockerignore to keep build artifacts and development folders out of the Docker context

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c958084680832c9d1daa83c44c19ab