### PR TITLE
Prevent audio init from hanging when resume is blocked

### DIFF
--- a/src/core/audio.js
+++ b/src/core/audio.js
@@ -45,7 +45,21 @@ export class AudioManager {
     this.gain.connect(this.context.destination);
     this.stepBuffer = createStepBuffer(this.context);
     this.initialized = true;
-    await this.context.resume();
+
+    try {
+      const resumePromise = this.context.resume();
+      if (resumePromise instanceof Promise) {
+        resumePromise.catch((error) => {
+          console.warn('AudioContext resume rejected', error);
+        });
+        await Promise.race([
+          resumePromise,
+          new Promise((resolve) => setTimeout(resolve, 250)),
+        ]);
+      }
+    } catch (error) {
+      console.warn('AudioContext resume failed', error);
+    }
   }
 
   async ensure() {


### PR DESCRIPTION
## Summary
- avoid hanging the initialization sequence when AudioContext.resume() waits for a user gesture
- add defensive logging for resume failures so audio issues are visible in the debug log

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c965a05540832cab1eb5d8f6ac9896