### PR TITLE
Make canvas adapt to full-screen mobile view

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,8 +32,10 @@
       #app {
         position: relative;
         flex: 1;
+        width: 100vw;
+        height: 100vh;
         display: flex;
-        align-items: center;
+        align-items: stretch;
         justify-content: center;
         overflow: hidden;
       }
@@ -41,10 +43,11 @@
       canvas {
         image-rendering: pixelated;
         image-rendering: crisp-edges;
-        max-width: 100vw;
-        max-height: 100vh;
-        width: 100%;
-        height: auto;
+        width: 100vw;
+        height: 100vh;
+        max-width: none;
+        max-height: none;
+        display: block;
       }
 
       #overlay-root {

--- a/src/app/GameApp.js
+++ b/src/app/GameApp.js
@@ -55,7 +55,11 @@ export class GameApp {
     this.destroyed = false;
 
     this.buildTargetsForWagon(wagon);
-    window.addEventListener('resize', () => this.display.resize());
+    this.handleViewportResize = () => this.display.resize();
+    window.addEventListener('resize', this.handleViewportResize);
+    if (window.visualViewport) {
+      window.visualViewport.addEventListener('resize', this.handleViewportResize);
+    }
     this.debug.setStatus('Создание приложения');
     this.debug.log('game.constructor', {
       startWagon: wagon.id,
@@ -252,6 +256,10 @@ export class GameApp {
     }
     if (this.inputRouter) {
       this.inputRouter.detach();
+    }
+    window.removeEventListener('resize', this.handleViewportResize);
+    if (window.visualViewport) {
+      window.visualViewport.removeEventListener('resize', this.handleViewportResize);
     }
     logger.info('GameApp destroyed');
   }

--- a/src/render/CanvasDisplay.js
+++ b/src/render/CanvasDisplay.js
@@ -18,7 +18,8 @@ export class CanvasDisplay {
       throw new Error('Failed to create buffer context');
     }
     this.bufferCtx = bufferCtx;
-    this.scale = 1;
+    this.scaleX = 1;
+    this.scaleY = 1;
     this.configureSmoothing();
     this.resize();
   }
@@ -29,14 +30,26 @@ export class CanvasDisplay {
   }
 
   resize() {
-    const { innerWidth, innerHeight } = window;
-    const scaleX = Math.floor(innerWidth / this.config.virtualWidth) || 1;
-    const scaleY = Math.floor(innerHeight / this.config.virtualHeight) || 1;
-    this.scale = Math.max(1, Math.min(scaleX, scaleY));
-    this.canvas.width = this.config.virtualWidth * this.scale;
-    this.canvas.height = this.config.virtualHeight * this.scale;
-    this.canvas.style.width = `${this.canvas.width}px`;
-    this.canvas.style.height = `${this.canvas.height}px`;
+    const viewport = window.visualViewport;
+    const cssWidth = Math.max(
+      1,
+      Math.ceil(viewport?.width ?? window.innerWidth ?? this.config.virtualWidth),
+    );
+    const cssHeight = Math.max(
+      1,
+      Math.ceil(viewport?.height ?? window.innerHeight ?? this.config.virtualHeight),
+    );
+    const pixelRatio = window.devicePixelRatio ?? 1;
+    const pixelWidth = Math.max(1, Math.ceil(cssWidth * pixelRatio));
+    const pixelHeight = Math.max(1, Math.ceil(cssHeight * pixelRatio));
+
+    this.canvas.width = pixelWidth;
+    this.canvas.height = pixelHeight;
+    this.canvas.style.width = `${cssWidth}px`;
+    this.canvas.style.height = `${cssHeight}px`;
+
+    this.scaleX = this.canvas.width / this.config.virtualWidth;
+    this.scaleY = this.canvas.height / this.config.virtualHeight;
     this.configureSmoothing();
   }
 
@@ -52,12 +65,12 @@ export class CanvasDisplay {
     this.ctx.save();
     this.ctx.imageSmoothingEnabled = false;
     this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
-    this.ctx.scale(this.scale, this.scale);
+    this.ctx.scale(this.scaleX, this.scaleY);
     this.ctx.drawImage(this.buffer, 0, 0);
     this.ctx.restore();
   }
 
   getScale() {
-    return this.scale;
+    return { x: this.scaleX, y: this.scaleY };
   }
 }


### PR DESCRIPTION
## Summary
- update the canvas display to size itself from the actual viewport dimensions and device pixel ratio
- ensure the game app reacts to both window and visual viewport resize events
- adjust layout styles so the canvas stretches across the full screen on mobile devices

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9781337ec832c943c37d0b2203b95